### PR TITLE
Ensure the package is installed

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,5 +13,6 @@
 Here is an example `use-package` configuration:
 ```elisp
 (use-package shadowenv
+  :ensure t
   :hook (after-init . shadowenv-global-mode))
 ```


### PR DESCRIPTION
The current documentation suggests to enable `shadowenv-global-mode` right after loading all init files. Emacs files to initialize in case `shadowenv` package is not installed.

This PR fixes the documentation by suggesting the user to force the installation of `shadowenv` package before calling the `shadowenv-global-mode`.